### PR TITLE
Correct docker-compose command in README.md to run in broker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ docker-compose up -d
 Show a stream of transactions in the topic `T` (optionally add `--from-beginning`):
 
 ```bash
-$ docker-compose -f docker-compose.kafka.yml exec kafka-console-consumer --bootstrap-server localhost:9092 --topic T
+$ docker-compose -f docker-compose.kafka.yml exec broker kafka-console-consumer --bootstrap-server localhost:9092 --topic T
 ```
 
 Topics:


### PR DESCRIPTION
The command tries to execute in a `kafka-console-consumer` service, which doesn't exist. It's a command.

I believe this was meant to run a `broker` container. 

Found during Community Open Hack Day: https://www.meetup.com/ltcphx/events/260505250/